### PR TITLE
setting up sleep tracker fragment with data source and view model

### DIFF
--- a/app/src/main/java/com/example/android/trackmysleepquality/sleeptracker/SleepTrackerFragment.kt
+++ b/app/src/main/java/com/example/android/trackmysleepquality/sleeptracker/SleepTrackerFragment.kt
@@ -22,7 +22,9 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
 import com.example.android.trackmysleepquality.R
+import com.example.android.trackmysleepquality.database.SleepDatabase
 import com.example.android.trackmysleepquality.databinding.FragmentSleepTrackerBinding
 
 /**
@@ -43,6 +45,29 @@ class SleepTrackerFragment : Fragment() {
         // Get a reference to the binding object and inflate the fragment views.
         val binding: FragmentSleepTrackerBinding = DataBindingUtil.inflate(
                 inflater, R.layout.fragment_sleep_tracker, container, false)
+
+        // we need a reference to the application that this fragment is attached to
+        // to pass into the ViewModelFactory provider
+        val application = requireNotNull(this.activity).application
+
+        // we need a reference to a data source via a reference to the DAO
+        val dataSource = SleepDatabase.getInstance(application).sleepDatabaseDao
+
+        // create an instance of the SleepTrackerViewModelFactory
+        // pass it the data source as well as the application
+        val viewModelFactory = SleepTrackerViewModelFactory(dataSource, application)
+
+        // ask the ViewModelProvider for a SleepTrackerViewModel
+        // we pass in our ViewModelFactory and request an instance of the SleepTrackerViewModel
+        val sleepTrackerViewModel =
+            ViewModelProvider(
+                this, viewModelFactory).get(SleepTrackerViewModel::class.java)
+
+        // we specify the current activity as the lifecycle owner of the binding
+        binding.setLifecycleOwner(this)
+
+        // assign the sleepTrackerViewModel to the binding
+        binding.sleepTrackerViewModel = sleepTrackerViewModel
 
         return binding.root
     }

--- a/app/src/main/java/com/example/android/trackmysleepquality/sleeptracker/SleepTrackerViewModel.kt
+++ b/app/src/main/java/com/example/android/trackmysleepquality/sleeptracker/SleepTrackerViewModel.kt
@@ -24,8 +24,14 @@ import com.example.android.trackmysleepquality.database.SleepDatabaseDao
 /**
  * ViewModel for SleepTrackerFragment.
  */
+
+// takes application context as a parameter and makes it available as a property
 class SleepTrackerViewModel(
         val database: SleepDatabaseDao,
         application: Application) : AndroidViewModel(application) {
+
+// it is a good practice to just use the minimum objects to keep database and view model cleanly separate
+
+
 }
 

--- a/app/src/main/res/layout/fragment_sleep_tracker.xml
+++ b/app/src/main/res/layout/fragment_sleep_tracker.xml
@@ -23,7 +23,9 @@
          the whole ViewModel, so that we can access the LiveData,
          click handlers, and state variables. -->
     <data>
-
+        <variable
+            name="sleepTrackerViewModel"
+            type="com.example.android.trackmysleepquality.sleeptracker.SleepTrackerViewModel" />
     </data>
 
     <!-- Start of the visible fragment layout using ConstraintLayout -->


### PR DESCRIPTION
- sets up data source for sleep tracker fragment using database and application context
- gets view model from view model factory and assigns view model to the data binding
- adds sleep tracker view model to fragment layout as a data element